### PR TITLE
Fix GOT sections missing from linker scripts causing kernel hang

### DIFF
--- a/kernel/memory.c
+++ b/kernel/memory.c
@@ -37,7 +37,8 @@ static size_t stat_free = 0;      // Total bytes free
 static int stat_alloc_count = 0;  // Number of active allocations
 
 // Defined in linker script - end of BSS in RAM
-extern uint64_t _bss_end;
+// Declared as char[] so the symbol name gives the address directly
+extern char _bss_end[];
 
 // Stack location (must match boot.S!)
 #ifdef TARGET_PI
@@ -72,7 +73,7 @@ void memory_init(void) {
 
     // Heap starts after BSS, aligned to 16 bytes
     // Add 64KB buffer after BSS for safety
-    heap_start = ALIGN_UP((uint64_t)&_bss_end + 0x10000, 16);
+    heap_start = ALIGN_UP((uint64_t)_bss_end + 0x10000, 16);
 
     // Heap ends well before the stack - leave room for programs!
     // Programs load after heap_end, so we need to reserve space.

--- a/linker-pi.ld
+++ b/linker-pi.ld
@@ -47,6 +47,9 @@ SECTIONS
         _data_start = .;
         *(.data)
         *(.data.*)
+        /* GOT sections must be included (contain runtime addresses) */
+        *(.got)
+        *(.got.plt)
         _data_end = .;
     } > RAM
 

--- a/linker.ld
+++ b/linker.ld
@@ -52,6 +52,9 @@ SECTIONS
         _data_start = .;
         *(.data)
         *(.data.*)
+        /* GOT sections must be in RAM (contain runtime addresses) */
+        *(.got)
+        *(.got.plt)
         _data_end = .;
     } > RAM
 


### PR DESCRIPTION
## Summary

Fixes a kernel hang that occurred immediately after the memory initialization message:
```
[MEM] heap: 0x10000 - 0x5af00000, stack at 0x5f000000
```

## Root Cause

The Global Offset Table (GOT) sections were not included in the linker scripts, causing the kernel to crash when accessing global variables.

### Technical Details

1. **What is the GOT?**
   - The compiler generates `.got` and `.got.plt` sections for position-independent code
   - These contain runtime addresses for global variables and function pointers
   - When code accesses a global variable like `free_list`, it goes through the GOT

2. **Why did it hang?**
   - On QEMU, code runs from flash (0x0) but data lives in RAM (0x40000000+)
   - The boot code copies the `.data` section from flash to RAM
   - The `.got` sections were NOT included in `.data`, so they weren't copied
   - The GOT in RAM contained uninitialized garbage addresses
   - First global variable access (`free_list = (block_header_t *)heap_start`) used a garbage pointer → hang

3. **The fix:**
   - Add `*(.got)` and `*(.got.plt)` to the `.data` section in both linker scripts
   - Also fixed `_bss_end` declaration from `extern uint64_t` to `extern char[]` (linker symbols should be declared as arrays so the name gives the address directly)

## Changes

- `linker.ld` - Added GOT sections to .data (QEMU)
- `linker-pi.ld` - Added GOT sections to .data (Raspberry Pi)
- `kernel/memory.c` - Fixed `_bss_end` declaration style

## Test plan

- [ ] `make run` boots past memory init on QEMU
- [ ] `make TARGET=pi` builds correctly for Raspberry Pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)